### PR TITLE
Add Florianópolis (SC) spider

### DIFF
--- a/processing/data_collection/gazette/spiders/sc_florianopolis.py
+++ b/processing/data_collection/gazette/spiders/sc_florianopolis.py
@@ -12,7 +12,7 @@ class ScFlorianopolisSpider(Spider):
     name = 'sc_florianopolis'
     URL = 'http://www.pmf.sc.gov.br/governo/index.php?pagina=govdiariooficial'
     MUNICIPALITY_ID = '4205407'
-    AVAILABLE_FROM = date(2009, 6, 1)
+    AVAILABLE_FROM = date(2015, 1, 1)  # actually from June/2009
 
     def start_requests(self):
         """The City Hall website publish the gazettes in a page with a form

--- a/processing/data_collection/gazette/spiders/sc_florianopolis.py
+++ b/processing/data_collection/gazette/spiders/sc_florianopolis.py
@@ -30,7 +30,7 @@ class ScFlorianopolisSpider(Spider):
             target = target + relativedelta(months=1)
 
     def parse(self, response):
-        """Parse each page. Eahc list all gazettes for a given month.
+        """Parse each page. Each list all gazettes for a given month.
         @url http://www.pmf.sc.gov.br/governo/index.php?pagina=govdiariooficial
         @returns items 1
         @scrapes date file_urls is_extra_edition municipality_id power scraped_at

--- a/processing/data_collection/gazette/spiders/sc_florianopolis.py
+++ b/processing/data_collection/gazette/spiders/sc_florianopolis.py
@@ -18,7 +18,10 @@ class ScFlorianopolisSpider(Spider):
         """The City Hall website publish the gazettes in a page with a form
         that allow users to browse through different years and months. This
         form sends requests via POST, so this method emulates a series of these
-        POSTs."""
+        POSTs.
+        @url http://www.pmf.sc.gov.br/governo/index.php?pagina=govdiariooficial
+        @returns requests 1
+        """
         target = date.today()
         while target >= self.AVAILABLE_FROM:
             year, month = str(target.year), str(target.month)
@@ -27,7 +30,11 @@ class ScFlorianopolisSpider(Spider):
             target = target + relativedelta(months=1)
 
     def parse(self, response):
-        """Parse each page. Eahc list all gazettes for a given month."""
+        """Parse each page. Eahc list all gazettes for a given month.
+        @url http://www.pmf.sc.gov.br/governo/index.php?pagina=govdiariooficial
+        @returns items 1
+        @scrapes date file_urls is_extra_edition municipality_id power scraped_at
+        """
         for link in response.css('ul.listagem li a'):
             url = self.get_pdf_url(response, link)
             if not url:
@@ -63,4 +70,4 @@ class ScFlorianopolisSpider(Spider):
     @staticmethod
     def is_extra(link):
         text = ' '.join(link.css('::text').extract())
-        return 'extra' in (text.lower().split())
+        return 'extra' in text.lower()

--- a/processing/data_collection/gazette/spiders/sc_florianopolis.py
+++ b/processing/data_collection/gazette/spiders/sc_florianopolis.py
@@ -45,7 +45,7 @@ class ScFlorianopolisSpider(Spider):
                 file_urls=(url,),
                 is_extra_edition=self.is_extra(link),
                 municipality_id=self.MUNICIPALITY_ID,
-                power='all',
+                power='executive_legislature',
                 scraped_at=datetime.utcnow(),
             )
 

--- a/processing/data_collection/gazette/spiders/sc_florianopolis.py
+++ b/processing/data_collection/gazette/spiders/sc_florianopolis.py
@@ -1,0 +1,54 @@
+from datetime import date, datetime
+
+from dateparser import parse
+from dateutil.relativedelta import relativedelta
+from scrapy import FormRequest, Spider
+
+from gazette.items import Gazette
+
+
+class ScFlorianopolisSpider(Spider):
+    name = 'sc_florianopolis'
+    URL = 'http://www.pmf.sc.gov.br/governo/index.php?pagina=govdiariooficial'
+    MUNICIPALITY_ID = '4205407'
+    AVAILABLE_FROM = date(2009, 6, 1)
+
+    def start_requests(self):
+        """The City Hall website publish the gazettes in a page with a form
+        that allow users to browse through different years and months. This
+        form sends requests via POST, so this method emulates a series of these
+        POSTs."""
+        target = date.today()
+        while target >= self.AVAILABLE_FROM:
+            year, month = str(target.year), str(target.month)
+            data = dict(ano=year, mes=month, passo='1', enviar='')
+            yield FormRequest(url=self.URL, formdata=data, callback=self.parse)
+            target = target + relativedelta(months=1)
+
+    def parse(self, response):
+        """Parse each page. Eahc list all gazettes for a given month."""
+        for link in response.css('ul.listagem li a'):
+            url = self.get_pdf_url(response, link)
+            if not url:
+                continue
+
+            yield Gazette(
+                date=self.get_date(link),
+                file_urls=(url,),
+                is_extra_edition=None,
+                municipality_id=self.MUNICIPALITY_ID,
+                power='all',
+                scraped_at=datetime.utcnow(),
+            )
+
+    @staticmethod
+    def get_pdf_url(response, link):
+        relative_url = link.css('::attr(href)').extract_first()
+        if not relative_url.lower().endswith('.pdf'):
+            return None
+
+        return response.urljoin(relative_url)
+
+    def get_date(self, link):
+        *_, date_as_str = link.css('::text').extract()
+        return parse(date_as_str.strip(), languages=('pt',)).date()

--- a/processing/database/__init__.py
+++ b/processing/database/__init__.py
@@ -1,1 +1,5 @@
-MUNICIPALITIES = {'4314902': 'RsPortoAlegre', '5208707': 'GoGoiania'}
+MUNICIPALITIES = {
+    '4205407': 'ScFlorianopolis',
+    '4314902': 'RsPortoAlegre',
+    '5208707': 'GoGoiania'
+}

--- a/processing/requirements.txt
+++ b/processing/requirements.txt
@@ -2,8 +2,9 @@ celery==4.1.0
 dateparser==0.7.0
 ipdb==0.11
 psycopg2-binary==2.7.4
+python-dateutil==2.7.2
 python-decouple==3.1
+redis==2.10.6
 requests==2.18.4
 scrapy==1.5.0
 SQLAlchemy==1.2.5
-redis==2.10.6


### PR DESCRIPTION
Yay, first lines of code in this awesome project!

Some doubts:

**~~1. About `powers` field~~**

~~Florianópolis seams to have an unique gazette for all powers (for example, in [this issue](http://www.pmf.sc.gov.br/arquivos/diario/pdf/31_05_2016_19.03.05.676c30944d7e7b1879a9ca0143e32de7.pdf) we can see in the table of contents that it covers the executive and the legislative). This I hardcoded `powers=None` – is that ok or is there a better way to record that?~~

**UPDATE** Thanks for the [tip](https://github.com/okfn-brasil/diario-oficial/pull/2#discussion_r179343101), @brunolellis : )

**~~2. About `is_extra_edition` fields~~**

~~I browsed Florianópolis portal a bit and I've found no _extra_ issues so far. Thus I also hardcoded `is_extra_edition=False` – is that ok or is there a better way to ponder on that?~~

**UPDATE** I've found one, now I know how to parse it.

**3. How to know if the spider is working?**

I ran it manually as I haven't seen anything in the logs of `docker-compose run`:

```console:
$ docker-compose run --rm processing bash 
root@processing # cd data_collection/gazette
root@processing # scrapy runspider spiders/sc_florianopolis.py
```

Was there a better way to test it?