### PR TITLE
Overriding file_path

### DIFF
--- a/processing/data_collection/gazette/parser.py
+++ b/processing/data_collection/gazette/parser.py
@@ -9,7 +9,7 @@ class GazetteFilesPipeline(FilesPipeline):
         url = request.url
         media_guid = hashlib.sha1(to_bytes(url)).hexdigest()
         media_ext = os.path.splitext(url)[1]
+        # scrapy bug. for more details see issue #15
         if not media_ext.isalnum():
-            # scrapy bug. for more details see issue #15
             media_ext = os.path.splitext(urlparse(url).path)[1]
         return 'full/%s%s' % (media_guid, media_ext)

--- a/processing/data_collection/gazette/parser.py
+++ b/processing/data_collection/gazette/parser.py
@@ -4,12 +4,27 @@ from scrapy.pipelines.files import FilesPipeline
 from scrapy.utils.python import to_bytes
 from six.moves.urllib.parse import urlparse
 
+"""Pipeline to handle URL containing query parameters.
+
+This pipeline is a temporary parser to remove existing query parameters in a URL string.
+Example:
+- The URL to download a gazette from Rio de Janeiro is http://doweb.rio.rj.gov.br/ler_pdf.php?download=ok&edi_id=3651
+- Scrapy uses URL's sha1 to store the file locally
+- However, Scrapy also uses the query parameter as file extension
+Resulting filename: '4f15e18052b51dd8dffad1cc243279f40a2e21c3.php?download=ok&edi_id=3651'
+- GazetteFilesPipeline ignores everything after file extension ('?download=ok&edi_id=3651')
+and resulting in the following filename: '4f15e18052b51dd8dffad1cc243279f40a2e21c3.php'
+
+This pipeline is temporary and could be deleted as soon as https://github.com/scrapy/scrapy/pull/2809 gets merged
+
+For more details, see https://github.com/okfn-brasil/diario-oficial/issues/15
+
+"""
 class GazetteFilesPipeline(FilesPipeline):
     def file_path(self, request, response=None, info=None):
         url = request.url
-        media_guid = hashlib.sha1(to_bytes(url)).hexdigest()
+        media_guid = hashlib.sha1(to_bytes(url)).hexdigest() # the filename is the URL's sha1
         media_ext = os.path.splitext(url)[1]
-        # scrapy bug. for more details see issue #15
         if not media_ext.isalnum():
-            media_ext = os.path.splitext(urlparse(url).path)[1]
+            media_ext = os.path.splitext(urlparse(url).path)[1] # remove everything after the file extension (like query param)
         return 'full/%s%s' % (media_guid, media_ext)

--- a/processing/data_collection/gazette/parser.py
+++ b/processing/data_collection/gazette/parser.py
@@ -1,7 +1,7 @@
-from scrapy.pipelines.files import FilesPipeline
-from scrapy.utils.python import to_bytes
 import os
 import hashlib
+from scrapy.pipelines.files import FilesPipeline
+from scrapy.utils.python import to_bytes
 from six.moves.urllib.parse import urlparse
 
 class GazetteFilesPipeline(FilesPipeline):
@@ -12,5 +12,4 @@ class GazetteFilesPipeline(FilesPipeline):
         if not media_ext.isalnum():
             # scrapy bug. for more details see issue #15
             media_ext = os.path.splitext(urlparse(url).path)[1]
-        import ipdb; ipdb.set_trace()
         return 'full/%s%s' % (media_guid, media_ext)

--- a/processing/data_collection/gazette/parser.py
+++ b/processing/data_collection/gazette/parser.py
@@ -1,0 +1,16 @@
+from scrapy.pipelines.files import FilesPipeline
+from scrapy.utils.python import to_bytes
+import os
+import hashlib
+from six.moves.urllib.parse import urlparse
+
+class GazetteFilesPipeline(FilesPipeline):
+    def file_path(self, request, response=None, info=None):
+        url = request.url
+        media_guid = hashlib.sha1(to_bytes(url)).hexdigest()
+        media_ext = os.path.splitext(url)[1]
+        if not media_ext.isalnum():
+            # scrapy bug. for more details see issue #15
+            media_ext = os.path.splitext(urlparse(url).path)[1]
+        import ipdb; ipdb.set_trace()
+        return 'full/%s%s' % (media_guid, media_ext)

--- a/processing/data_collection/gazette/settings.py
+++ b/processing/data_collection/gazette/settings.py
@@ -3,7 +3,8 @@ SPIDER_MODULES = ['gazette.spiders']
 NEWSPIDER_MODULE = 'gazette.spiders'
 ROBOTSTXT_OBEY = False
 ITEM_PIPELINES = {
-    'scrapy.pipelines.files.FilesPipeline': 1,
+    #'scrapy.pipelines.files.FilesPipeline': 1,
+    'gazette.parser.GazetteFilesPipeline': 1,
     'gazette.pipelines.PdfParsingPipeline': 2,
     'gazette.pipelines.PostgreSQLPipeline': 3,
 }

--- a/processing/data_collection/gazette/settings.py
+++ b/processing/data_collection/gazette/settings.py
@@ -3,7 +3,6 @@ SPIDER_MODULES = ['gazette.spiders']
 NEWSPIDER_MODULE = 'gazette.spiders'
 ROBOTSTXT_OBEY = False
 ITEM_PIPELINES = {
-    #'scrapy.pipelines.files.FilesPipeline': 1,
     'gazette.parser.GazetteFilesPipeline': 1,
     'gazette.pipelines.PdfParsingPipeline': 2,
     'gazette.pipelines.PostgreSQLPipeline': 3,

--- a/processing/data_collection/gazette/settings.py
+++ b/processing/data_collection/gazette/settings.py
@@ -4,6 +4,7 @@ NEWSPIDER_MODULE = 'gazette.spiders'
 ROBOTSTXT_OBEY = False
 ITEM_PIPELINES = {
     'gazette.pipelines.GazetteDateFilteringPipeline': 50,
+    'gazette.parser.GazetteFilesPipeline': 60,
     'scrapy.pipelines.files.FilesPipeline': 100,
     'gazette.pipelines.PdfParsingPipeline': 200,
     'gazette.pipelines.PostgreSQLPipeline': 300,


### PR DESCRIPTION
As discussed in issue #15, scrapy has a bug when request URL contains query parameters.