### PR TITLE
Add Maceió (AL) spider

### DIFF
--- a/CITIES.md
+++ b/CITIES.md
@@ -24,7 +24,7 @@ The municipality id (IBGE code) can be found on [Wikipedia](https://pt.wikipedia
 | 14 | Campinas | :white_check_mark: | | | [PR](https://github.com/okfn-brasil/diario-oficial/pull/2) |
 | 15 | São Luís | :soon: | | | [PR](https://github.com/okfn-brasil/diario-oficial/pull/22) |
 | 16 | São Gonçalo | | | | |
-| 17 | Maceió | :soon: | | | [PR](https://github.com/okfn-brasil/diario-oficial/pull/32) |
+| 17 | Maceió | :white_check_mark: | | | [PR](https://github.com/okfn-brasil/diario-oficial/pull/32) |
 | 18 | Duque de Caxias | | | | |
 | 19 | Natal | :soon: | | | [PR](https://github.com/okfn-brasil/diario-oficial/pull/60) |
 | 20 | Campo Grande | :soon: | | | [PR](https://github.com/okfn-brasil/diario-oficial/pull/35) |

--- a/processing/data_collection/gazette/spiders/al_maceio.py
+++ b/processing/data_collection/gazette/spiders/al_maceio.py
@@ -1,0 +1,76 @@
+from dateparser import parse
+from datetime import datetime
+
+import scrapy
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+
+class AlMaceioSpider(BaseGazetteSpider):
+    MUNICIPALITY_ID = '2704302'
+    name = 'al_maceio'
+    allowed_domains = ['maceio.al.gov.br']
+    start_urls = ['http://www.maceio.al.gov.br/noticias/diario-oficial/']
+    page_number = 1
+
+    def parse(self, response):
+        """
+        @url http://www.maceio.al.gov.br/noticias/diario-oficial/
+        @returns items 0 9
+        @returns requests 1 10
+        @scrapes date file_urls is_extra_edition municipality_id power scraped_at
+        """
+        gazettes = list(response.xpath('//article'))
+        for gazette in gazettes:
+            url = gazette.xpath('a/@href').extract_first()
+
+            if not url: # In some cases the href attr is empty, e.g. 24-11-2015
+                continue
+
+            date_str = gazette.xpath('time/text()').extract_first()
+            date = parse(date_str, languages=['pt'])
+            title = gazette.xpath('a/@title').extract_first()
+            is_extra_edition = 'suplemento' in (title.lower())
+
+            if 'wp-content/uploads' in url:
+                gazette = self.create_gazette(date, url, is_extra_edition)
+                yield gazette
+            else:
+                request = scrapy.Request(url, self.parse_additional_page)
+                request.meta['date'] = date
+                request.meta['is_extra_edition'] = is_extra_edition
+                yield request
+
+        """
+        This condition is necessary to stop crawling when there are no more gazettes
+        """
+        if gazettes:
+            self.page_number += 1
+            yield scrapy.Request(
+                '{0}/page/{1}'.format(self.start_urls[0],
+                str(self.page_number))
+            )
+
+    def parse_additional_page(self, response):
+        """
+        @url http://www.maceio.al.gov.br/noticias/diario-oficial/
+        @returns items 1 9
+        @returns requests 1
+        @scrapes date file_urls is_extra_edition municipality_id power scraped_at
+        """
+        url = response.xpath('//p[@class="attachment"]/a/@href').extract_first()
+        gazette = self.create_gazette(response.meta['date'],
+                                      url,
+                                      response.meta['is_extra_edition'])
+        yield gazette
+
+    def create_gazette(self, date, url, is_extra_edition):
+        return Gazette(
+            date=date,
+            file_urls=[url],
+            is_extra_edition=is_extra_edition,
+            municipality_id=self.MUNICIPALITY_ID,
+            power='executive_legislature',
+            scraped_at=datetime.utcnow(),
+        )


### PR DESCRIPTION
Maceió is the 17th largest city in Brazil by population. This spider collects data from http://www.maceio.al.gov.br/noticias/diario-oficial/.

The `parse_additional_page` callback is necessary because some gazettes have a direct link to download and others open a new page upon click. For the same reason the scrapy contracts have different values for min and max ranges, because in some cases we will have more or less requests per gazette. The value is unpredictable because the page contents change according to new gazette uploads.