### PR TITLE
Use the correct method for retrieving the list of initial requests

### DIFF
--- a/processing/data_collection/gazette/spiders/sp_guarulhos.py
+++ b/processing/data_collection/gazette/spiders/sp_guarulhos.py
@@ -11,15 +11,13 @@ class SpGuarulhosSpider(scrapy.Spider):
     MUNICIPALITY_ID = '3518800'
     name = 'sp_guarulhos'
     allowed_domains = ['guarulhos.sp.gov.br']
-    urls = []
-    starting_date = dt.date(2015, 1, 1)
-    ending_date = dt.date.today()
-    for date in rrule(MONTHLY, dtstart=starting_date, until=ending_date):
-        url = "http://www.guarulhos.sp.gov.br/diario-oficial/index.php?mes={}&ano={}".format(
-            date.month, date.year
-        )
-        urls.append(url)
-    start_urls = urls
+
+    def start_requests(self):
+        base_url = 'http://www.guarulhos.sp.gov.br/diario-oficial/index.php?mes={}&ano={}'
+        starting_date = dt.date(2015, 1, 1)
+        ending_date = dt.date.today()
+        for date in rrule(MONTHLY, dtstart=starting_date, until=ending_date):
+            yield scrapy.Request(base_url.format(date.month, date.year))
 
     def parse(self, response):
         """

--- a/processing/data_collection/gazette/spiders/sp_guarulhos.py
+++ b/processing/data_collection/gazette/spiders/sp_guarulhos.py
@@ -13,11 +13,11 @@ class SpGuarulhosSpider(scrapy.Spider):
     allowed_domains = ['guarulhos.sp.gov.br']
 
     def start_requests(self):
-        base_url = 'http://www.guarulhos.sp.gov.br/diario-oficial/index.php?mes={}&ano={}'
         starting_date = dt.date(2015, 1, 1)
         ending_date = dt.date.today()
         for date in rrule(MONTHLY, dtstart=starting_date, until=ending_date):
-            yield scrapy.Request(base_url.format(date.month, date.year))
+            yield scrapy.Request(
+                f'http://www.guarulhos.sp.gov.br/diario-oficial/index.php?mes={date.month}&ano={date.year}')
 
     def parse(self, response):
         """

--- a/processing/data_collection/gazette/spiders/sp_guarulhos.py
+++ b/processing/data_collection/gazette/spiders/sp_guarulhos.py
@@ -22,7 +22,7 @@ class SpGuarulhosSpider(scrapy.Spider):
     def parse(self, response):
         """
         @url http://www.guarulhos.sp.gov.br/diario-oficial/index.php?mes=1&ano=2018
-        @returns items 16 16
+        @returns items 17 17
         @scrapes date file_urls is_extra_edition municipality_id power scraped_at
         """
         diarios = response.xpath('//div[contains(@id, "diario")]')


### PR DESCRIPTION
According to Scrapy documentation, the preferred method to return the list of the Requests that will be parsed is using the method _start_requests_:
https://doc.scrapy.org/en/latest/topics/spiders.html#scrapy.spiders.Spider.start_requests

cc/ @gustavodemari 