### PR TITLE
Filter item by date

### DIFF
--- a/processing/data_collection/gazette/pipelines.py
+++ b/processing/data_collection/gazette/pipelines.py
@@ -2,7 +2,9 @@ import os
 import subprocess
 
 from database.models import Gazette, db_connect, create_tables
+from scrapy.exceptions import DropItem
 from sqlalchemy.orm import sessionmaker
+
 
 from gazette.settings import FILES_STORE
 
@@ -48,4 +50,14 @@ class PostgreSQLPipeline(object):
 
         finally:
             session.close()
+        return item
+
+
+class GazetteDateFilteringPipeline(object):
+
+    def process_item(self, item, spider):
+        if hasattr(spider, 'start_date'):
+            if spider.start_date > item.get('date'):
+                raise DropItem(
+                    'Droping all items before {}'.format(spider.start_date))
         return item

--- a/processing/data_collection/gazette/settings.py
+++ b/processing/data_collection/gazette/settings.py
@@ -3,8 +3,9 @@ SPIDER_MODULES = ['gazette.spiders']
 NEWSPIDER_MODULE = 'gazette.spiders'
 ROBOTSTXT_OBEY = False
 ITEM_PIPELINES = {
-    'scrapy.pipelines.files.FilesPipeline': 1,
-    'gazette.pipelines.PdfParsingPipeline': 2,
-    'gazette.pipelines.PostgreSQLPipeline': 3,
+    'gazette.pipelines.GazetteDateFilteringPipeline': 50,
+    'scrapy.pipelines.files.FilesPipeline': 100,
+    'gazette.pipelines.PdfParsingPipeline': 200,
+    'gazette.pipelines.PostgreSQLPipeline': 300,
 }
 FILES_STORE = '/mnt/data/'

--- a/processing/data_collection/gazette/spiders/base.py
+++ b/processing/data_collection/gazette/spiders/base.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+import dateparser
+import scrapy
+
+
+class BaseGazetteSpider(scrapy.Spider):
+
+    def __init__(self, start_date=None, *args, **kwargs):
+        super(BaseGazetteSpider, self).__init__(*args, **kwargs)
+
+        if start_date is not None:
+            parsed_data = dateparser.parse(start_date)
+            if parsed_data is not None:
+                self.start_date = parsed_data.date()

--- a/processing/data_collection/gazette/spiders/sp_guarulhos.py
+++ b/processing/data_collection/gazette/spiders/sp_guarulhos.py
@@ -5,9 +5,10 @@ from dateutil.rrule import rrule, MONTHLY
 import scrapy
 
 from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
 
 
-class SpGuarulhosSpider(scrapy.Spider):
+class SpGuarulhosSpider(BaseGazetteSpider):
     MUNICIPALITY_ID = '3518800'
     name = 'sp_guarulhos'
     allowed_domains = ['guarulhos.sp.gov.br']

--- a/processing/data_collection/gazette/spiders/sp_guarulhos.py
+++ b/processing/data_collection/gazette/spiders/sp_guarulhos.py
@@ -25,7 +25,7 @@ class SpGuarulhosSpider(BaseGazetteSpider):
     def parse(self, response):
         """
         @url http://www.guarulhos.sp.gov.br/diario-oficial/index.php?mes=1&ano=2018
-        @returns items 16 16
+        @returns items 17 17
         @scrapes date file_urls is_extra_edition municipality_id power scraped_at
         """
         diarios = response.xpath('//div[contains(@id, "diario")]')


### PR DESCRIPTION
First implementation of an item pipeline that will drop any item that has a date before _start_date_ parameter (sent to the spider), avoiding it to be downloaded.

Related to #39 .

cc @Irio