### PR TITLE
Inherit all spiders from base spider class

### DIFF
--- a/processing/data_collection/gazette/spiders/ba_feira_de_santana.py
+++ b/processing/data_collection/gazette/spiders/ba_feira_de_santana.py
@@ -5,9 +5,10 @@ import scrapy
 from scrapy.http import Request
 
 from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
 
 
-class BaFeiraDeSantanaSpider(scrapy.Spider):
+class BaFeiraDeSantanaSpider(BaseGazetteSpider):
     MUNICIPALITY_ID = '2910800'
     name = 'ba_feira_de_santana'
     allowed_domains = ['diariooficial.feiradesantana.ba.gov.br']

--- a/processing/data_collection/gazette/spiders/es_associacao_municipios.py
+++ b/processing/data_collection/gazette/spiders/es_associacao_municipios.py
@@ -4,9 +4,10 @@ import datetime as dt
 import scrapy
 
 from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
 
 
-class EsAssociacaoMunicipiosSpider(scrapy.Spider):
+class EsAssociacaoMunicipiosSpider(BaseGazetteSpider):
     MUNICIPALITY_ID = '3200000'
     name = 'es_associacao_municipios'
     allowed_domains = ['diariomunicipales.org.br']

--- a/processing/data_collection/gazette/spiders/go_goiania.py
+++ b/processing/data_collection/gazette/spiders/go_goiania.py
@@ -5,9 +5,10 @@ import re
 import scrapy
 
 from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
 
 
-class GoGoianiaSpider(scrapy.Spider):
+class GoGoianiaSpider(BaseGazetteSpider):
     MUNICIPALITY_ID = '5208707'
     name = 'go_goiania'
     allowed_domains = ['goiania.go.gov.br']

--- a/processing/data_collection/gazette/spiders/rj_rio_de_janeiro.py
+++ b/processing/data_collection/gazette/spiders/rj_rio_de_janeiro.py
@@ -2,8 +2,10 @@ from gazette.items import Gazette
 import datetime as dt
 import re
 import scrapy
+from gazette.spiders.base import BaseGazetteSpider
 
-class RjRioDeJaneiroSpider(scrapy.Spider):
+
+class RjRioDeJaneiroSpider(BaseGazetteSpider):
     MUNICIPALITY_ID = '3304557'
     name = 'rj_rio_de_janeiro'
     allowed_domains = ['doweb.rio.rj.gov.br']
@@ -17,7 +19,7 @@ class RjRioDeJaneiroSpider(scrapy.Spider):
         while parsing_date >= end_date:
             url = self.search_gazette_url.format(parsing_date.strftime('%d/%m/%Y'))
             yield scrapy.Request(url, self.parse_search_by_date, meta={'gazette_date': parsing_date})
-            
+
             parsing_date = parsing_date - dt.timedelta(days=1)
 
     def parse_search_by_date(self, response):
@@ -44,7 +46,7 @@ class RjRioDeJaneiroSpider(scrapy.Spider):
                     url = self.download_gazette_url.format(match.group(1))
                     is_extra_edition = 'suplemento' in ed.lower()
                     items.append(self.create_gazette(gazette_date, url, is_extra_edition))
-        
+
         return items
 
     def create_gazette(self, date, url, is_extra_edition=False):

--- a/processing/data_collection/gazette/spiders/rs_caxias_do_sul.py
+++ b/processing/data_collection/gazette/spiders/rs_caxias_do_sul.py
@@ -5,9 +5,10 @@ import scrapy
 from scrapy.http import Request
 
 from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
 
 
-class RsCaxiasDoSulSpider(scrapy.Spider):
+class RsCaxiasDoSulSpider(BaseGazetteSpider):
     MUNICIPALITY_ID = '4305108'
     name = 'rs_caxias_do_sul'
     allowed_domains = ['caxias.rs.gov.br']

--- a/processing/data_collection/gazette/spiders/rs_porto_alegre.py
+++ b/processing/data_collection/gazette/spiders/rs_porto_alegre.py
@@ -4,9 +4,10 @@ import datetime as dt
 import scrapy
 
 from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
 
 
-class RsPortoAlegreSpider(scrapy.Spider):
+class RsPortoAlegreSpider(BaseGazetteSpider):
     MUNICIPALITY_ID = '4314902'
     name = 'rs_porto_alegre'
     allowed_domains = ['portoalegre.rs.gov.br']

--- a/processing/data_collection/gazette/spiders/sc_florianopolis.py
+++ b/processing/data_collection/gazette/spiders/sc_florianopolis.py
@@ -3,12 +3,13 @@ from datetime import date, datetime
 
 from dateparser import parse
 from dateutil.relativedelta import relativedelta
-from scrapy import FormRequest, Spider
+from scrapy import FormRequest
 
 from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
 
 
-class ScFlorianopolisSpider(Spider):
+class ScFlorianopolisSpider(BaseGazetteSpider):
     name = 'sc_florianopolis'
     URL = 'http://www.pmf.sc.gov.br/governo/index.php?pagina=govdiariooficial'
     MUNICIPALITY_ID = '4205407'

--- a/processing/data_collection/gazette/spiders/sp_campinas.py
+++ b/processing/data_collection/gazette/spiders/sp_campinas.py
@@ -5,9 +5,10 @@ import datetime as dt
 import scrapy
 
 from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
 
 
-class SpCampinasSpider(scrapy.Spider):
+class SpCampinasSpider(BaseGazetteSpider):
     MUNICIPALITY_ID = '3509502'
     name = 'sp_campinas'
     allowed_domains = ['campinas.sp.gov.br']

--- a/processing/data_collection/gazette/spiders/sp_franca.py
+++ b/processing/data_collection/gazette/spiders/sp_franca.py
@@ -5,9 +5,10 @@ import json
 import scrapy
 
 from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
 
 
-class SpFrancaSpider(scrapy.Spider):
+class SpFrancaSpider(BaseGazetteSpider):
     MUNICIPALITY_ID = '3516200'
     name = 'sp_franca'
     allowed_domains = ['franca.sp.gov.br']

--- a/processing/data_collection/gazette/spiders/sp_santos.py
+++ b/processing/data_collection/gazette/spiders/sp_santos.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
-from dateparser import parse
-from gazette.items import Gazette
 import datetime as dt
-import json
-import scrapy
 
-class SpSantosSpider(scrapy.Spider):
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+
+class SpSantosSpider(BaseGazetteSpider):
     MUNICIPALITY_ID = '3548500'
     name = 'sp_santos'
     allowed_domains = ['santos.sp.gov.br']

--- a/processing/data_collection/gazette/spiders/to_araguaina.py
+++ b/processing/data_collection/gazette/spiders/to_araguaina.py
@@ -5,11 +5,12 @@ import datetime as dt
 import scrapy
 
 from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
 
 only_number_regex = re.compile(r'\D*')
 
 
-class ToAraguainaSpider(scrapy.Spider):
+class ToAraguainaSpider(BaseGazetteSpider):
     MUNICIPALITY_ID = '1702109'
     name = 'to_araguaina'
     allowed_domains = [

--- a/processing/data_collection/gazette/spiders/to_palmas.py
+++ b/processing/data_collection/gazette/spiders/to_palmas.py
@@ -4,11 +4,12 @@ import requests
 import scrapy
 
 from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
 
 last_page_number_xpath = '//div[@class="paginacao"]/ul[@class="pagination"]/li[last()-1]/a[last()]/text()'
 
 
-class ToPalmasSpider(scrapy.Spider):
+class ToPalmasSpider(BaseGazetteSpider):
     MUNICIPALITY_ID = '1721000'
     name = 'to_palmas'
     allowed_domains = ['diariooficial.palmas.to.gov.br', 'legislativo.palmas.to.gov.br']


### PR DESCRIPTION
This PR included a spider base class that allows us to specify the start_date we want for the gazettes to be retrieved (or the ones that should be ignored):
 https://github.com/okfn-brasil/diario-oficial/pull/41

I updated all existing spiders to inherit from this class. Everything will work exactly the same, but now we have the option to execute the spider passing `start_date` parameter.