### PR TITLE
paremetize processing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 API_URL=http://api:3000
 DATA_FOLDER=./data
+PROCESSING_FOLDER=./processing
 DATABASE_URL=postgres://gazette:BGAyWfZccGuHqFcWvy8WFgv7@postgres:5432/gazette
 DEBUG=True
 NODE_ENV=development

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - .env
     volumes:
       - ${DATA_FOLDER}:/mnt/data
-      - ./processing:/mnt/code
+      - ${PROCESSING_FOLDER}:/mnt/code
 
   rabbitmq:
     image: rabbitmq:3-alpine


### PR DESCRIPTION
WSL and older docker setups may require absolute paths from host mount. Parametizing the processing folder allows to keep docker-compose.yml clean. 