### PR TITLE
Don't expose Postgres port in Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,6 @@ services:
     env_file:
       - .env
     image: postgres:10-alpine
-    ports:
-      - 5432:5432
 
   processing:
     build: processing


### PR DESCRIPTION
This avoids `docker-compose up` failing if ran on a machine that has Postgres
running locally on the same port. As the other containers access Postgres via
Docker, they'll continue working regardless if we're exposing its port or not.
Also, if we need to access the DB for whatever reason, we can get the random IP
assigned by Docker using `docker inspect` and use it instead.