### PR TITLE
Use Python 3.6 on processing's Dockerfile

### DIFF
--- a/processing/Dockerfile
+++ b/processing/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.6
 
 WORKDIR /mnt/code
 


### PR DESCRIPTION
This avoids a new version of Python coming out and breaking the code, as has happened now with Python 3.7 (which our dependency Celery doesn't support), that creates the following error:

```
processing_1  | [2018-07-07 12:16:51,570: CRITICAL/MainProcess] Unrecoverable error: SyntaxError('invalid syntax', ('/usr/local/lib/python3.
7/site-packages/celery/backends/redis.py', 21, 19, 'from . import async, base\n'))
processing_1  | Traceback (most recent call last):
processing_1  |   File "/usr/local/lib/python3.7/site-packages/kombu/utils/objects.py", line 42, in __get__
processing_1  |     return obj.__dict__[self.__name__]
processing_1  | KeyError: 'backend'
processing_1  | 
processing_1  | During handling of the above exception, another exception occurred:
processing_1  | 
processing_1  | Traceback (most recent call last):
processing_1  |   File "/usr/local/lib/python3.7/site-packages/celery/worker/worker.py", line 205, in start
processing_1  |     self.blueprint.start(self)
processing_1  |   File "/usr/local/lib/python3.7/site-packages/celery/bootsteps.py", line 115, in start
processing_1  |     self.on_start()
processing_1  |   File "/usr/local/lib/python3.7/site-packages/celery/apps/worker.py", line 139, in on_start
processing_1  |     self.emit_banner()
processing_1  |   File "/usr/local/lib/python3.7/site-packages/celery/apps/worker.py", line 154, in emit_banner
processing_1  |     ' \n', self.startup_info(artlines=not use_image))),
processing_1  |   File "/usr/local/lib/python3.7/site-packages/celery/apps/worker.py", line 217, in startup_info
processing_1  |     results=self.app.backend.as_uri(),
processing_1  |   File "/usr/local/lib/python3.7/site-packages/kombu/utils/objects.py", line 44, in __get__
processing_1  |     value = obj.__dict__[self.__name__] = self.__get(obj)
processing_1  |   File "/usr/local/lib/python3.7/site-packages/celery/app/base.py", line 1174, in backend
processing_1  |     return self._get_backend()
processing_1  |   File "/usr/local/lib/python3.7/site-packages/celery/app/base.py", line 892, in _get_backend
processing_1  |     self.loader)
processing_1  |   File "/usr/local/lib/python3.7/site-packages/celery/app/backends.py", line 68, in by_url
processing_1  |     return by_name(backend, loader), url
processing_1  |   File "/usr/local/lib/python3.7/site-packages/celery/app/backends.py", line 48, in by_name
processing_1  |     cls = symbol_by_name(backend, aliases)
processing_1  |   File "/usr/local/lib/python3.7/site-packages/kombu/utils/imports.py", line 56, in symbol_by_name
processing_1  |     module = imp(module_name, package=package, **kwargs)
processing_1  |   File "/usr/local/lib/python3.7/importlib/__init__.py", line 127, in import_module
processing_1  |     return _bootstrap._gcd_import(name[level:], package, level)
processing_1  |   File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
processing_1  |   File "<frozen importlib._bootstrap>", line 983, in _find_and_load
processing_1  |   File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
processing_1  |   File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
processing_1  |   File "<frozen importlib._bootstrap_external>", line 724, in exec_module
processing_1  |   File "<frozen importlib._bootstrap_external>", line 860, in get_code
processing_1  |   File "<frozen importlib._bootstrap_external>", line 791, in source_to_code
processing_1  |   File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
processing_1  |   File "/usr/local/lib/python3.7/site-packages/celery/backends/redis.py", line 21
processing_1  |     from . import async, base
processing_1  |                       ^
processing_1  | SyntaxError: invalid syntax
diariooficial_processing_1 exited with code 1
```

Pinning to Python 3.6 fixes this issue and avoids it happening again in the future.