### PR TITLE
Use pytest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ htmlcov/
 .coverage
 .coverage.*
 .cache
+.pytest_cache
 nosetests.xml
 coverage.xml
 *.cover

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 test: unit_test integration_test
 
 unit_test:
-	docker-compose run --rm processing python -m unittest discover
+	docker-compose run --rm processing pytest -p no:cacheprovider
 
 integration_test:
 	docker-compose run --rm processing bash -c "cd data_collection && scrapy check"

--- a/processing/data_collection/gazette/middlewares.py
+++ b/processing/data_collection/gazette/middlewares.py
@@ -6,7 +6,7 @@
 from scrapy import signals
 
 
-class GazetteSpiderMiddleware(object):
+class GazetteSpiderMiddleware:
 
     # Not all methods need to be defined. If a method is not defined,
     # scrapy acts as if the spider middleware does not modify the
@@ -50,7 +50,7 @@ class GazetteSpiderMiddleware(object):
         spider.logger.info("Spider opened: %s" % spider.name)
 
 
-class GazetteDownloaderMiddleware(object):
+class GazetteDownloaderMiddleware:
 
     # Not all methods need to be defined. If a method is not defined,
     # scrapy acts as if the downloader middleware does not modify the

--- a/processing/data_collection/gazette/pipelines.py
+++ b/processing/data_collection/gazette/pipelines.py
@@ -30,7 +30,7 @@ class PdfParsingPipeline:
             return file.read()
 
 
-class PostgreSQLPipeline(object):
+class PostgreSQLPipeline:
     def __init__(self):
         engine = initialize_database()
         self.Session = sessionmaker(bind=engine)
@@ -55,7 +55,7 @@ class PostgreSQLPipeline(object):
         return item
 
 
-class GazetteDateFilteringPipeline(object):
+class GazetteDateFilteringPipeline:
     def process_item(self, item, spider):
         if hasattr(spider, "start_date"):
             if spider.start_date > item.get("date"):

--- a/processing/data_collection/gazette/spiders/ba_salvador.py
+++ b/processing/data_collection/gazette/spiders/ba_salvador.py
@@ -73,7 +73,7 @@ class BaSalvadorSpider(BaseGazetteSpider):
         )
 
 
-class BaSalvadorExtraEditionItemPipeline(object):
+class BaSalvadorExtraEditionItemPipeline:
     def process_item(self, item, spider):
         item["is_extra_edition"] = False
 

--- a/processing/data_collection/gazette/spiders/pr_cascavel.py
+++ b/processing/data_collection/gazette/spiders/pr_cascavel.py
@@ -7,11 +7,11 @@ from gazette.spiders.base import BaseGazetteSpider
 
 
 class PrCascavelSpider(BaseGazetteSpider):
-    TERRITORY_ID = '4104808'
-    name = 'pr_cascavel'
-    allowed_domains = ['cascavel.pr.gov.br']
-    start_urls = ['http://www.cascavel.pr.gov.br/servicos/orgao_oficial.php']
-    download_url = 'http://www.cascavel.pr.gov.br/anexos/{}'
+    TERRITORY_ID = "4104808"
+    name = "pr_cascavel"
+    allowed_domains = ["cascavel.pr.gov.br"]
+    start_urls = ["http://www.cascavel.pr.gov.br/servicos/orgao_oficial.php"]
+    download_url = "http://www.cascavel.pr.gov.br/anexos/{}"
 
     def parse(self, response):
         """
@@ -19,20 +19,20 @@ class PrCascavelSpider(BaseGazetteSpider):
         @returns items 1
         @scrapes date file_urls is_extra_edition territory_id power scraped_at
         """
-        for row in response.xpath('//table//tr[position()>1]'):
-            date = row.xpath('.//td[2]//font//text()').extract_first()
-            date = parse(date, languages=['pt']).date()
-            for link in row.xpath('.//td[3]//a'):
-                link_text = link.xpath('.//text()').extract_first()
-                power = 'executive' if 'Executivo' in link_text else 'legislature'
-                url = response.urljoin(link.xpath('./@href').extract_first(''))
+        for row in response.xpath("//table//tr[position()>1]"):
+            date = row.xpath(".//td[2]//font//text()").extract_first()
+            date = parse(date, languages=["pt"]).date()
+            for link in row.xpath(".//td[3]//a"):
+                link_text = link.xpath(".//text()").extract_first()
+                power = "executive" if "Executivo" in link_text else "legislature"
+                url = response.urljoin(link.xpath("./@href").extract_first(""))
                 yield Gazette(
                     date=date,
                     file_urls=[url],
                     is_extra_edition=False,
                     territory_id=self.TERRITORY_ID,
                     power=power,
-                    scraped_at=dt.datetime.utcnow()
+                    scraped_at=dt.datetime.utcnow(),
                 )
         next_page_xpath = '//a[@title="Próxima página"]/@href'
         next_page_url = response.xpath(next_page_xpath).extract_first()

--- a/processing/requirements.txt
+++ b/processing/requirements.txt
@@ -10,3 +10,4 @@ redis==2.10.6
 requests==2.18.4
 scrapy==1.5.0
 SQLAlchemy==1.2.5
+pytest

--- a/processing/tests/gazette/data/test_bidding_exemption_parsing.py
+++ b/processing/tests/gazette/data/test_bidding_exemption_parsing.py
@@ -1,11 +1,10 @@
-from unittest import TestCase
 from unittest.mock import MagicMock, PropertyMock, patch
 
 from gazette.data.bidding_exemption_parsing import BiddingExemptionParsing
 
 
-class TestBiddingExemptionParsing(TestCase):
-    def setUp(self):
+class TestBiddingExemptionParsing:
+    def setup_method(self, _):
         session = MagicMock()
         self.subject = BiddingExemptionParsing(session)
 
@@ -55,86 +54,85 @@ class TestBiddingExemptionParsing(TestCase):
         ]
         self.subject.update(exemptions)
         for exemption in exemptions:
-            self.assertEqual(True, exemption.is_parsed)
+            assert exemption.is_parsed
 
     def test_update_object_using_label(self):
         object = "Aquisição de 05 (cinco) cabos HDMI 2.0 com 10 metros cada."
         exemption = MagicMock(data={"OBJETO": object})
         self.subject.update_object(exemption)
-        self.assertEqual(object, exemption.object)
+        assert object == exemption.object
 
     def test_update_object_using_label_with_introduction_1(self):
         object = "Trata o Presente de Ato de Dispensa de Licitação prevista no artigo 24 inciso II da Lei 8.666 de 1993 tendo por objeto a aquisição de serviços de dedetização, desratização e limpeza da caixa d’água das áreas I e II da AGCMG;"
         exemption = MagicMock(data={"OBJETO": object})
         self.subject.update_object(exemption)
-        self.assertEqual(
-            "serviços de dedetização, desratização e limpeza da caixa d’água das áreas I e II da AGCMG;",
-            exemption.object,
-        )
+
+        expected_object = "serviços de dedetização, desratização e limpeza da caixa d’água das áreas I e II da AGCMG;"
+        assert expected_object == exemption.object
 
     def test_update_object_using_label_with_introduction_2(self):
         object = "Trata o presente de Ato de Dispensa de Licitação prevista no artigo 24 inciso II da Lei nº 8.666 de 1993, tendo por objeto aquisição de Certificado Digital PJ1, para atender o Fundo Municipal da Guarda Civil Metropolitana - FMGCM."
         exemption = MagicMock(data={"OBJETO": object})
         self.subject.update_object(exemption)
-        self.assertEqual(
-            "Certificado Digital PJ1, para atender o Fundo Municipal da Guarda Civil Metropolitana - FMGCM.",
-            exemption.object,
-        )
+
+        expected_object = "Certificado Digital PJ1, para atender o Fundo Municipal da Guarda Civil Metropolitana - FMGCM."
+        assert expected_object == exemption.object
 
     def test_update_value_label_1(self):
         value = "R$ 4.064,10 (Quatro mil, sessenta e quatro reais e dez centavos)."
         exemption = MagicMock(data={"VALOR TOTAL": value})
         self.subject.update_value(exemption)
-        self.assertEqual(4064.1, exemption.value)
+
+        assert 4064.1 == exemption.value
 
     def test_update_value_label_2(self):
         value = "R$ 4.064,10 (Quatro mil, sessenta e quatro reais e dez centavos)."
         exemption = MagicMock(data={"ORÇAMENTO PREVISTO": value})
         self.subject.update_value(exemption)
-        self.assertEqual(4064.1, exemption.value)
+        assert 4064.1 == exemption.value
 
     def test_update_value_label_3(self):
         value = "R$ 4.064,10 (Quatro mil, sessenta e quatro reais e dez centavos)."
         exemption = MagicMock(data={"PREÇO TOTAL": value})
         self.subject.update_value(exemption)
-        self.assertEqual(4064.1, exemption.value)
+        assert 4064.1 == exemption.value
 
     def test_update_value_specific_case_with_multiple_commas(self):
         exemption = MagicMock(
             data={"PREÇO TOTAL": "R$ 660,00,00 (seiscentos e sessenta reais)"}
         )
         self.subject.update_value(exemption)
-        self.assertEqual(660., exemption.value)
+        assert 660.0 == exemption.value
 
     def test_update_contracted_label_1(self):
         exemption = MagicMock(data={"CONTRATADO": "Petrobras"})
         self.subject.update_contracted(exemption)
-        self.assertEqual("Petrobras", exemption.contracted)
+        assert "Petrobras" == exemption.contracted
 
     def test_update_contracted_label_2(self):
         exemption = MagicMock(data={"EMPRESAS CONTRATADAS": "Petrobras"})
         self.subject.update_contracted(exemption)
-        self.assertEqual("Petrobras", exemption.contracted)
+        assert "Petrobras" == exemption.contracted
 
     def test_update_contracted_label_3(self):
         exemption = MagicMock(data={"EMPRESA BENEFICIADA": "Petrobras"})
         self.subject.update_contracted(exemption)
-        self.assertEqual("Petrobras", exemption.contracted)
+        assert "Petrobras" == exemption.contracted
 
     def test_update_contracted_label_4(self):
         exemption = MagicMock(data={"FORNECEDOR": "Petrobras"})
         self.subject.update_contracted(exemption)
-        self.assertEqual("Petrobras", exemption.contracted)
+        assert "Petrobras" == exemption.contracted
 
     def test_update_contracted_label_5(self):
         exemption = MagicMock(data={"LOCADOR": "Petrobras"})
         self.subject.update_contracted(exemption)
-        self.assertEqual("Petrobras", exemption.contracted)
+        assert "Petrobras" == exemption.contracted
 
     def test_update_contracted_code_from_contracted(self):
         exemption = MagicMock(contracted="BR GÁS LTDA-ME, CNPJ nº 08.926.037/0001-57.")
         self.subject.update_contracted_code(exemption)
-        self.assertEqual("08926037000157", exemption.contracted_code)
+        assert "08926037000157" == exemption.contracted_code
 
     def test_update_contracted_code_from_source_text(self):
         exemption = MagicMock(
@@ -142,7 +140,7 @@ class TestBiddingExemptionParsing(TestCase):
             source_text="- EMPRESAS CONTRATADAS: BR GÁS LTDA-ME, CNPJ nº 08.926.037/0001-57.\n- VALOR TOTAL: R$ 3.240,00 (Três mil, duzentos e quarenta reais).",
         )
         self.subject.update_contracted_code(exemption)
-        self.assertEqual("08926037000157", exemption.contracted_code)
+        assert "08926037000157" == exemption.contracted_code
 
     def test_update_contracted_code_when_cnpj_is_not_present(self):
         exemption = MagicMock(
@@ -151,7 +149,7 @@ class TestBiddingExemptionParsing(TestCase):
             source_text="- EMPRESAS CONTRATADAS: BR GÁS LTDA-ME.\n- VALOR TOTAL: R$ 3.240,00 (Três mil, duzentos e quarenta reais).",
         )
         self.subject.update_contracted_code(exemption)
-        self.assertIsNone(exemption.contracted_code)
+        assert exemption.contracted_code is None
 
     def test_update_contracted_code_when_multiple_cnpjs_in_source_text(self):
         exemption = MagicMock(
@@ -160,4 +158,4 @@ class TestBiddingExemptionParsing(TestCase):
             source_text="- ÓRGÃO CONTRATANTE: Agência da Guarda Civil Metropolitana de Goiânia – AGCMG,\n         CNPJ nº 57.494.031/0010-54.\n         - EMPRESAS CONTRATADAS: REDE EPI EQUIPAMENTOS DE SEGURANÇA EIRELI,\n         CNPJ nº 18.428.558/0001-38.",
         )
         self.subject.update_contracted_code(exemption)
-        self.assertIsNone(exemption.contracted_code)
+        assert exemption.contracted_code is None

--- a/processing/tests/gazette/data/test_row_update.py
+++ b/processing/tests/gazette/data/test_row_update.py
@@ -1,11 +1,10 @@
-from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
 from gazette.data.row_update import RowUpdate
 
 
-class TestRowUpdate(TestCase):
-    def setUp(self):
+class TestRowUpdate:
+    def setup_method(self, method):
         self.subject = RowUpdate(MagicMock)
 
     @patch.object(RowUpdate, "filtered_rows")

--- a/processing/tests/gazette/data/test_section_parsing.py
+++ b/processing/tests/gazette/data/test_section_parsing.py
@@ -1,11 +1,10 @@
-from unittest import TestCase
 from unittest.mock import MagicMock, PropertyMock, patch
 
 from gazette.data.section_parsing import SectionParsing
 
 
-class TestSectionParsing(TestCase):
-    def setUp(self):
+class TestSectionParsing:
+    def setup_method(self, _):
         session = MagicMock()
         self.subject = SectionParsing(session)
 
@@ -25,7 +24,7 @@ class TestSectionParsing(TestCase):
         ]
         self.subject.update(gazettes)
         for gazette in gazettes:
-            self.assertEqual(True, gazette.is_parsed)
+            assert gazette.is_parsed
 
     def test_update_doesnt_change_is_parsed_when_has_no_parser(self):
         gazettes = [
@@ -33,8 +32,8 @@ class TestSectionParsing(TestCase):
             MagicMock(is_parsed=False, territory_id="42"),
         ]
         self.subject.update(gazettes)
-        self.assertEqual(True, gazettes[0].is_parsed)
-        self.assertEqual(False, gazettes[1].is_parsed)
+        assert gazettes[0].is_parsed
+        assert not gazettes[1].is_parsed
 
     def test_update_doesnt_raise_exception_with_territory_wo_parser(self):
         gazettes = [MagicMock(territory_id="42")]
@@ -48,7 +47,5 @@ class TestSectionParsing(TestCase):
         exceptions = [{"data": {"key": "value"}, "source_text": "key: value"}]
         parser.bidding_exemptions.return_value = exceptions
         self.subject.update_bidding_exemptions(gazette, parser)
-        self.assertEqual(exceptions[0]["data"], gazette.bidding_exemptions[0].data)
-        self.assertEqual(
-            exceptions[0]["source_text"], gazette.bidding_exemptions[0].source_text
-        )
+        assert exceptions[0]["data"] == gazette.bidding_exemptions[0].data
+        assert exceptions[0]["source_text"] == gazette.bidding_exemptions[0].source_text

--- a/processing/tests/gazette/locations/test_go_goiania.py
+++ b/processing/tests/gazette/locations/test_go_goiania.py
@@ -1,5 +1,3 @@
-from unittest import TestCase, skip
-
 from gazette.locations.go_goiania import GoGoiania
 
 
@@ -10,8 +8,8 @@ def subject_2():
     return GoGoiania(text)
 
 
-class TestGoGoiania(TestCase):
-    def setUp(self):
+class TestGoGoiania:
+    def setup_method(self, _):
         path = "tests/gazette/fixtures/go_goiania.txt"
         with open(path) as file:
             self.text = file.read()
@@ -19,7 +17,7 @@ class TestGoGoiania(TestCase):
 
     def test_pages(self):
         pages = self.subject.pages()
-        self.assertEqual(241, len(pages))
+        assert 241 == len(pages)
         expected_expressions = (
             "Criado pela Lei nº 1.552, de 21/08/1959",
             "Versão digital instituída pelo Decreto nº 3.987, de 14/08/2013",
@@ -28,7 +26,7 @@ class TestGoGoiania(TestCase):
             "PILOTO:88708985120",
         )
         for expected in expected_expressions:
-            self.assertIn(expected, pages[0])
+            assert expected in pages[0]
 
     def test_bidding_exemptions(self):
         exemptions = self.subject.bidding_exemptions()
@@ -68,7 +66,7 @@ class TestGoGoiania(TestCase):
                 "source_text": "\n\n\n                                                                    Agência da Guarda Civil Metropolitana de Goiânia\n\n\n\n                                      EXTRATO DE ATO DE DISPENSA DE LICITAÇÃO\n\n\n\n\n         - PROCESSO: 388/2018.\n         - LOCAL E DATA: Goiânia, 07 de março de 2018.\n         - OBJETO: Trata o presente de Ato de Dispensa de Licitação prevista no artigo 24 inciso II da\n         Lei nº 8.666 de 1993, tendo por objeto aquisição de Certificado Digital PJ1, para atender o\n         Fundo Municipal da Guarda Civil Metropolitana - FMGCM.\n         - ÓRGÃO CONTRATANTE: Agência da Guarda Civil Metropolitana de Goiânia – AGCMG,\n         CNPJ nº 10.498.531/0001-00.\n         - EMPRESA CONTRATADA: SOLUTI – Soluções Em Negócios Inteligentes S/A, CNPJ nº\n         09.461.647/0001-95.\n         - VALOR TOTAL: R$ 210,00 (Duzentos e dez reais).\n\n\n\n\n                                                    JOSÉ EULÁLIO VIEIRA\n                                                Presidente-Comandante da AGCMG\n\n\n\n\nAv. Nazareno Roriz, nº 66 – Setor Castelo Branco – CEP: 74405-010\nFone: (62) 3524-8661 – Fax: (62) 3524-1947\nE-mail: presidenteagmg@hotmail.com\n\n\n      Prefeitura de Goiânia/ Sup. da Casa Civil e Articulação Política - Assinado Digitalmente: www.goiania.go.gov.br\n\x0cDOM Eletrônico                            Edição Nº 6772, de 14 de março de 2018.                 ",
             },
         ]
-        self.assertEqual(expectation, exemptions)
+        assert expectation == exemptions
 
     def test_bidding_exemptions_title_2(self):
         exemptions = subject_2().bidding_exemptions()
@@ -79,4 +77,4 @@ class TestGoGoiania(TestCase):
                 "source_text": "\n\n\n\n\n                            TERMO DE DISPENSA DE LICITAÇÃO Nº 002/2018\n\n\n\n\n                    O DIRETOR FINANCEIRO DA CÂMARA MUNICIPAL DE GOIÂNIA, no\n uso de suas atribuições legais estabelecidas pela Portaria nº 219, de 14 de março de 2017, de acordo\n com o contido no Processo nº 2018/465 e com fundamento no artigo 24, XIII, da Lei Federal nº\n 8666, de 23 de junho de 1993.\n\n\n                    DECLARA             ser    DISPENSÁVEL               a    licitação   relativa   à   contratação   da\n UNIVERSIDADE FEDERAL DE GOIÁS – UFG, (CNPJ/MF: 01.567.601/0001-43), para\n realização do concurso público para provimento de cargos efetivos deste Poder Legislativo, no valor\n estimado de R$ 1.621.586,16 (Um milhão, seiscentos e vinte e um mil, quinhentos e oitenta e seis\n reais e dezesseis centavos).\n\n\n\n\n                    Câmara Municipal de Goiânia, aos 17 dias do mês de abril do ano de 2018.\n\n\n\n\n                                  FRADIQUE MACHADO DE MIRANDA DIAS\n                                            Diretor Financeiro\n\n\n\n\n Av.\xa0Goiás,\xa0nº\xa02001\xa0–\xa0Setor\xa0Norte\xa0Ferroviário\xa0–\xa0Goiânia‐GO\xa0CEP\xa074.063‐900\xa0\xa0\xa0\xa0\xa0\xa0\n Fone:\xa055\xa062\xa03524.4218|\xa0e‐mail:\xa0procuradoria@camaragyn.go.gov.br\xa0\xa0\xa0\xa0\xa0\xa0\xa0\xa0\xa0\n\nPrefeitura de Goiânia/ Sup. da Casa Civil e Articulação Política - Assinado Digitalmente: www.goiania.go.gov.br\n\x0cDOM Eletrônico                       Edição Nº 6797, de 20 de abril de 2018.                ",
             }
         ]
-        self.assertEqual(expectation, exemptions)
+        assert expectation == exemptions

--- a/processing/tests/gazette/locations/test_rs_porto_alegre.py
+++ b/processing/tests/gazette/locations/test_rs_porto_alegre.py
@@ -1,10 +1,8 @@
-from unittest import TestCase
-
 from gazette.locations.rs_porto_alegre import RsPortoAlegre
 
 
-class TestRsPortoAlegre(TestCase):
-    def setUp(self):
+class TestRsPortoAlegre:
+    def setup_method(self, _):
         path = "tests/gazette/fixtures/rs_porto_alegre.txt"
         with open(path) as file:
             self.text = file.read()
@@ -12,8 +10,8 @@ class TestRsPortoAlegre(TestCase):
 
     def test_pages(self):
         pages = self.subject.pages()
-        self.assertEqual(19, len(pages))
-        self.assertEqual(self.text[:3498], pages[0].strip())
+        assert 19 == len(pages)
+        assert self.text[:3498] == pages[0].strip()
 
     def test_bidding_exemptions(self):
         exemptions = self.subject.bidding_exemptions()
@@ -51,4 +49,4 @@ class TestRsPortoAlegre(TestCase):
                 "source_text": "                                               DISPENSA DE LICITAÇÃO\n     PROCESSO 001.037017.14.4\n     CONTRATANTE: Município de Porto Alegre, através da Secretaria Municipal da Saúde.\n     CONTRATADO: VIP ELEVADORES LTDA\n     OBJETO: Conserto de componente eletrônico do armário de comando de elevador HMIPV, sem cobertura contratual.\n     VALOR: R$ 11.232,00 (onze mil reais, duzentos e trinta e dois reais).\n     BASE LEGAL: Artigo 24, inciso I, da Lei Federal 8.666/93\n\n                                                Porto Alegre, 24 de fevereiro de 2015..\n\n                                  CARLOS HENRIQUE CASARTELLI, Secretário Municipal de Saúde.",
             },
         ]
-        self.assertEqual(expectation, exemptions)
+        assert expectation == exemptions

--- a/processing/tests/test_tasks.py
+++ b/processing/tests/test_tasks.py
@@ -1,13 +1,13 @@
 import glob
-from unittest import TestCase
 from unittest.mock import call, patch
 
+import pytest
 from freezegun import freeze_time
 
 import tasks
 
 
-class TestTasks(TestCase):
+class TestTasks:
     @patch("tasks.BiddingExemption")
     @patch("tasks.BiddingExemptionParsing")
     @patch("tasks.RowUpdate")
@@ -50,7 +50,7 @@ class TestTasks(TestCase):
             if name not in ["__init__", "base"]:
                 new_call = call(["scrapy", "crawl", name], cwd="data_collection")
                 spider_calls.append(new_call)
-        self.assertEqual(popen.mock_calls, spider_calls)
+        assert popen.mock_calls == spider_calls
 
     @freeze_time("2018-01-08")
     @patch("tasks.subprocess.Popen")
@@ -61,5 +61,5 @@ class TestTasks(TestCase):
 
     @patch("tasks.subprocess.Popen")
     def test_run_spiders_using_unsupported_timerange(self, popen):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             tasks.run_spiders(["rs_porto_alegre"], timerange="past_month")

--- a/processing/tests/test_tasks.py
+++ b/processing/tests/test_tasks.py
@@ -1,3 +1,4 @@
+import os
 import glob
 from unittest.mock import call, patch
 
@@ -43,9 +44,12 @@ class TestTasks:
     @patch("tasks.subprocess.Popen")
     def test_run_spiders(self, popen):
         tasks.run_spiders()
-        spiders = "/mnt/code/data_collection/gazette/spiders/*.py"
+        current_folder = os.path.dirname(os.path.realpath(__file__))
+        spiders_glob = os.path.join(
+            current_folder, "..", "data_collection", "gazette", "spiders", "*.py"
+        )
         spider_calls = []
-        for module in sorted(glob.glob(spiders)):
+        for module in sorted(glob.glob(spiders_glob)):
             name = module.split("/")[-1].split(".")[0]
             if name not in ["__init__", "base"]:
                 new_call = call(["scrapy", "crawl", name], cwd="data_collection")


### PR DESCRIPTION
As we chatted in #109, this PR migrates the code from unittest from pytest.

On tox, I was able to set it up, but there were many issues because the `gazette` user inside the `processing` container can't write to the `/mnt/code` volume, as it comes from the host. I found two workarounds:

1) On the `ENTRYPOINT` use the script `docker-entrypoint.sh` (below) to change the `gazette`'s user ID to the owner of the `/mnt/code` (I can't simply chown the folder because that'll alter the owner in the user's host machine). This pattern is relatively common in Dockerland.
2) Configure `tox` and `pytest` to write their files outside `/mnt/code` (e.g. in `/mnt/data/.tox`)

Both work fine, although the 1st option caused other issues because we're sharing the `.pyc` files amongst different "machines" (the host and the guest). I got this exception:

```
import file mismatch:
imported module 'tests.gazette.locations.test_rs_porto_alegre' has this __file__ attribute:
  /home/vitor/Projetos/diario-oficial/processing/tests/gazette/locations/test_rs_porto_alegre.py
which is not the same as the test file we want to collect:
  /mnt/code/tests/gazette/locations/test_rs_porto_alegre.py
HINT: remove __pycache__ / .pyc files and/or use a unique basename for your test file modules
```

So the 2nd option was the best. But then I noticed the `scrapy check` tests don't run locally anyway (they hardcode paths like `/mnt/code`, and require the database to be up and running), so tox was only used to take care of the virtual envs and as a single place to document how to run the tests. The virtual envs aren't necessary inside the Docker container, and the Makefile is already enough documentation IMO.

Because of this, I think tox would only be useful if we want to move the linting out of a git hook into it (which I slightly prefer). As this turned out to be more complex and less useful than I anticipated, I went on and only migrated to pytest for now. I'll add the `tox.ini` file below, so we can use it if you'd like to migrate. Otherwise, this PR is good to go.

## Code to add tox

`processing/docker-entrypoint.sh`
```bash
#!/bin/bash

OWNER_UID=$(stat -c '%u' /mnt/code)
USER=gazette

usermod -u $OWNER_UID $USER
chown -R $USER /mnt/data

gosu $USER $@
```

`processing/tox.ini`
```
[tox]
envlist =
  py36
skipsdist = true

[testenv]
passenv =
  API_URL
  DATABASE_URL
  DEBUG
  PARSING_FREQUENCY_IN_SECONDS
  PGRST_DB_ANON_ROLE
  PGRST_DB_SCHEMA
  POSTGRES_PASSWORD
  POSTGRES_USER
  RABBITMQ_URL
  REDIS_URL
deps =
  -rrequirements.txt
  freezegun==0.3.10
  pytest
commands = pytest {posargs}

[testenv:scrapy]
changedir = {toxinidir}/data_collection
setenv =
  PYTHONPATH = {toxinidir}/data_collection{:}{toxinidir}
commands = scrapy check {posargs}
```

`Makefile`
```
unit_test:
	docker-compose run --rm processing tox --workdir /mnt/data/.tox -- -p no:cacheprovider

integration_test:
	docker-compose run --rm processing tox -e scrapy --workdir /mnt/data/.tox
```