### PR TITLE
Fix pre-commit installation in the setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,11 @@ setup:
 	docker-compose pull
 	docker-compose build
 	make seed
-	pip install --user pre-commit
+	@if [ -z $$VIRTUAL_ENV ]; then \
+		pip install --user pre-commit; \
+	else \
+		pip install pre-commit; \
+	fi
 	pre-commit install
 
 seed:

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ setup:
 	docker-compose pull
 	docker-compose build
 	make seed
-	pip install pre-commit
+	pip install --user pre-commit
 	pre-commit install
 
 seed:


### PR DESCRIPTION
**PIP** defaults the the package installations to a system directory, which requires root access. This is not desirable while running a setup script.