### PR TITLE
Simplify web container

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -4,14 +4,10 @@ ENV HOME /mnt/code
 ENV HOST 0.0.0.0
 ENV PORT 8080
 
-RUN npm install --quiet --global nuxt vue-cli
-
 COPY package*.json $HOME/
-
 WORKDIR $HOME
 RUN npm install
 
 COPY . $HOME
-
 EXPOSE $PORT
-CMD npm run build && npm run start
+CMD ["npm", "run", "start"]

--- a/web/README.md
+++ b/web/README.md
@@ -12,7 +12,6 @@ $ npm install # Or yarn install
 $ npm run dev
 
 # build for production and launch server
-$ npm run build
 $ npm start
 
 # generate static project

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "dev": "nuxt",
-    "build": "nuxt build",
+    "prestart": "nuxt build",
     "start": "nuxt start",
     "generate": "nuxt generate",
     "lint": "eslint --ext .js,.vue --ignore-path .gitignore .",
@@ -16,7 +16,8 @@
     "axios": "^0.18.0",
     "bulma": "^0.6.2",
     "npm": "^5.8.0",
-    "nuxt": "^1.0.0"
+    "nuxt": "^1.0.0",
+    "vue-cli": "^2.9.6"
   },
   "devDependencies": {
     "babel-eslint": "^8.2.1",


### PR DESCRIPTION
This commit simplifies the web container

* by avoiding installing npm packages globally (we can call them using npx or via npm scripts
instead)
* by using the prestart npm script to avoid the need of chaining two commands to run the server

Does that make sense, @guidiego?