### PR TITLE
Fix build with the new pytest 3.10.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 test: unit_test integration_test
 
 unit_test:
-	docker-compose run --rm processing pytest -p no:cacheprovider
+	docker-compose run --rm processing pytest
 
 integration_test:
 	docker-compose run --rm processing bash -c "cd data_collection && scrapy check"


### PR DESCRIPTION
#128 New pytest version (3.10.0) caused failure in tests (see https://github.com/pytest-dev/pytest/issues/4304). I removed the "-p no:cacheprovider" option from the command line and it worked.

I also manually removed my local docker images (python and diario-oficial*) so that it got the newest version of pytest, as in Travis.