### PR TITLE
Add Spider for RS Gravatai

### DIFF
--- a/CITIES.md
+++ b/CITIES.md
@@ -105,7 +105,7 @@ The municipality id (IBGE code) can be found on [Wikipedia](https://pt.wikipedia
 | 95 | Governador Valadares | :soon: | | [PR](https://github.com/okfn-brasil/diario-oficial/pull/19) |
 | 96 | Taboão da Serra | | | |
 | 97 | Santa Maria | | | |
-| 98 | Gravataí | | | |
+| 98 | Gravataí | :soon: | | | [PR](https://github.com/okfn-brasil/diario-oficial/pull/129) |
 | 99 | Várzea Grande | | | |
 | 100 | Abdon Batista | :white_check_mark: | | [PR](https://github.com/okfn-brasil/diario-oficial/pull/141) |
 | 101 | Agrolândia | :white_check_mark: | | [PR](https://github.com/okfn-brasil/diario-oficial/pull/141) |

--- a/processing/data_collection/gazette/spiders/rs_gravatai.py
+++ b/processing/data_collection/gazette/spiders/rs_gravatai.py
@@ -18,8 +18,9 @@ class RsGravataiSpider(BaseGazetteSpider):
     def parse(self, response):
         """
         @url https://gravatai.atende.net/?pg=diariooficial
-        @returns requests 68
+        @returns requests 1
         """
+
         last_page_number_css = "#paginacao > ul > li:nth-child(7) > button::attr(value)"
         last_page_number = int(response.css(last_page_number_css).extract_first())
 
@@ -49,8 +50,8 @@ class RsGravataiSpider(BaseGazetteSpider):
 
             code = element.css(".opcoes > button::attr(data-codigo)").extract_first()
             url = (
-                "https://gravatai.atende.net/atende.php?rot=54002&aca=737&"
-                "processo=download&codigo={codigo}".format(codigo=code)
+                "https://gravatai.atende.net/atende.php?rot=54002&aca=737"
+                f"&processo=download&codigo={code}"
             )
 
             yield Gazette(

--- a/processing/data_collection/gazette/spiders/rs_gravatai.py
+++ b/processing/data_collection/gazette/spiders/rs_gravatai.py
@@ -32,7 +32,7 @@ class RsGravataiSpider(BaseGazetteSpider):
     def parse_gazette(self, response):
         """
         @url https://gravatai.atende.net/?pg=diariooficial&pagina=1
-        @returns requests 15
+        @returns items 1
         @scrapes date file_urls is_extra_edition territory_id power scraped_at
         """
 

--- a/processing/data_collection/gazette/spiders/rs_gravatai.py
+++ b/processing/data_collection/gazette/spiders/rs_gravatai.py
@@ -1,0 +1,63 @@
+from dateparser import parse
+from datetime import datetime
+
+from scrapy import Request
+
+from gazette.items import Gazette
+from gazette.spiders.base import BaseGazetteSpider
+
+
+class RsGravataiSpider(BaseGazetteSpider):
+    TERRITORY_ID = "4309209"
+    name = "rs_gravatai"
+    allowed_domains = ["gravatai.atende.net"]
+    start_urls = ["https://gravatai.atende.net/?pg=diariooficial"]
+
+    extra_editions_options = ("Suplementar", "Retificação")
+
+    def parse(self, response):
+        """
+        @url https://gravatai.atende.net/?pg=diariooficial
+        @returns requests 68
+        """
+        last_page_number_css = "#paginacao > ul > li:nth-child(7) > button::attr(value)"
+        last_page_number = int(response.css(last_page_number_css).extract_first())
+
+        for page_number in range(1, last_page_number + 1):
+            yield Request(
+                f"https://gravatai.atende.net/?pg=diariooficial&pagina={page_number}",
+                callback=self.parse_gazette,
+            )
+
+    def parse_gazette(self, response):
+        """
+        @url https://gravatai.atende.net/?pg=diariooficial&pagina=1
+        @returns requests 15
+        @scrapes date file_urls is_extra_edition territory_id power scraped_at
+        """
+
+        for element in response.css(".nova_listagem > .linha"):
+            info = element.css(".info")
+
+            is_extra_edition = (
+                info.css(".tipo::text").extract_first() in self.extra_editions_options
+            )
+
+            date = parse(
+                info.css(".data::text").extract_first(), languages=["pt"]
+            ).date()
+
+            code = element.css(".opcoes > button::attr(data-codigo)").extract_first()
+            url = (
+                "https://gravatai.atende.net/atende.php?rot=54002&aca=737&"
+                "processo=download&codigo={codigo}".format(codigo=code)
+            )
+
+            yield Gazette(
+                date=date,
+                file_urls=[url],
+                is_extra_edition=is_extra_edition,
+                territory_id=self.TERRITORY_ID,
+                power="executive",
+                scraped_at=datetime.utcnow(),
+            )


### PR DESCRIPTION
This PR adds a Spider for the Gravatai city.

#### Questions 

Can someone explain me how can I check if the gazettes that I am crawling are from the legislative or executive legislature? You can check it here: https://gravatai.atende.net/?pg=diariooficial

#### Observartions
I had two problems when working on it. First one was when I tried to do my first commit... The pre-commit hook raised me this error:

```shell
[I] ~/d/diario-oficial ∙ git commit -m 'Update Rs Gravatai docstrings'                                                                                                                                          ᚴ upstream ⚡  rs_gravatai  1M
black....................................................................Failed
hookid: black

Starting diario-oficial_postgres_1 ... done
Starting diario-oficial_redis_1    ... done
Starting diario-oficial_rabbitmq_1 ... done
Usage: black [OPTIONS] [SRC]...
Try "black -h" for help.

Error: Invalid value for "[SRC]...": Path "processing/data_collection/gazette/spiders/rs_gravatai.py" does not exist.
```

Because of that I had to use black locally and used `--no-verify` to write this commit. I think that maybe it can be related to some cached files on my notebook (despite I had run a command that clears all the python cached files).

Second one was when I tried to run my spider:

```shell
019-01-27 01:39:02 [scrapy.core.scraper] ERROR: Error processing {'date': datetime.date(2015, 11, 30),
 'file_urls': ['https://gravatai.atende.net/atende.php?rot=54002&aca=737&processo=download&codigo=162'],
 'files': [{'checksum': '866c92a8386a71ff8a1181ff939eb563',
            'path': 'full/2d6023b5749cac810ed43379ddb499c843f6f0de.php?rot=54002&aca=737&processo=download&codigo=162',
            'url': 'https://gravatai.atende.net/atende.php?rot=54002&aca=737&processo=download&codigo=162'}],
 'is_extra_edition': False,
 'power': 'executive',
 'scraped_at': datetime.datetime(2019, 1, 27, 1, 38, 15, 985416),
 'territory_id': '4309209'}
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/twisted/internet/defer.py", line 654, in _runCallbacks
    current.result = callback(current.result, *args, **kw)
  File "/mnt/code/data_collection/gazette/pipelines.py", line 14, in process_item
    item["source_text"] = self.pdf_source_text(item)
  File "/mnt/code/data_collection/gazette/pipelines.py", line 29, in pdf_source_text
    with open(text_path) as file:
FileNotFoundError: [Errno 2] No such file or directory: '/mnt/data/full/2d6023b5749cac810ed43379ddb499c843f6f0de.php?rot=54002&aca=737&processo=download&codigo=162.txt'
```

Seems that the scraper can't find the downloaded file internally on the docker container. Is that ok?