### PR TITLE
base.py: makes FECAM spider run faster

### DIFF
--- a/processing/data_collection/gazette/spiders/base.py
+++ b/processing/data_collection/gazette/spiders/base.py
@@ -24,24 +24,30 @@ class FecamGazetteSpider(scrapy.Spider):
     total_pages = None
 
     def start_requests(self):
-        if self.total_pages is None:
-            yield scrapy.Request(
-                f"{self.URL}?q={self.FECAM_QUERY}", callback=self.parse
+        yield scrapy.Request(
+            f"{self.URL}?q={self.FECAM_QUERY}", callback=self.first_parse
+        )
+
+    def first_parse(self, response):
+        """
+        This parse function is used to get all the pages available and
+        return request object for each one
+        """
+        return [
+            scrapy.Request(
+                f"{self.URL}?q={self.FECAM_QUERY}&Search_page={i}", callback=self.parse
             )
+            for i in range(1, self.get_last_page(response) + 1)
+        ]
 
     def parse(self, response):
-        if self.total_pages is None:
-            self.total_pages = self.get_last_page(response)
+        """
+        Parse each page from the gazette page.
+        """
         # Get gazzete info
         documents = self.get_documents_links_date(response)
         for d in documents:
             yield self.get_gazette(d)
-        if self.total_pages > 1:
-            yield scrapy.Request(
-                f"{self.URL}?q={self.FECAM_QUERY}&Search_page={self.total_pages}",
-                callback=self.parse,
-            )
-            self.total_pages = self.total_pages - 1
 
     def get_documents_links_date(self, response):
         """

--- a/processing/data_collection/gazette/spiders/base.py
+++ b/processing/data_collection/gazette/spiders/base.py
@@ -25,10 +25,10 @@ class FecamGazetteSpider(scrapy.Spider):
 
     def start_requests(self):
         yield scrapy.Request(
-            f"{self.URL}?q={self.FECAM_QUERY}", callback=self.first_parse
+            f"{self.URL}?q={self.FECAM_QUERY}", callback=self.parse_pagination
         )
 
-    def first_parse(self, response):
+    def parse_pagination(self, response):
         """
         This parse function is used to get all the pages available and
         return request object for each one


### PR DESCRIPTION
Updates the FECAM spider to make it run faster. For that, instead of
return the next page after get all the gazettes files, the first request
find all the pages and returns a request object for each one. Thus,
scrapy can parallelize as much as possible.

Signed-off-by: José Guilherme Vanz <jvanz@jvanz.com>