### PR TITLE
Update Apache Tika

### DIFF
--- a/processing/Dockerfile
+++ b/processing/Dockerfile
@@ -5,12 +5,12 @@ WORKDIR /mnt/code
 COPY requirements.txt requirements.txt
 
 # install Apache Tika
-ADD http://ftp.unicamp.br/pub/apache/tika/tika-app-1.22.jar /
+ADD http://ftp.unicamp.br/pub/apache/tika/tika-app-1.23.jar /tika-app.jar
 
 RUN adduser --system -u ${LOCAL_USER_ID:-1000} gazette \
 	&& apt-get update \
 	&& apt-get -y install poppler-utils postgresql-client wait-for-it default-jre \
 	&& pip install --no-cache-dir -r requirements.txt \
-	&& chmod 755 /tika-app-1.22.jar
+	&& chmod 755 /tika-app.jar
 
 USER gazette

--- a/processing/data_collection/gazette/pipelines.py
+++ b/processing/data_collection/gazette/pipelines.py
@@ -83,7 +83,7 @@ class ExtractTextPipeline:
         """
         doc_path = os.path.join(FILES_STORE, item["files"][0]["path"])
         text_path = doc_path + ".txt"
-        command = f"java -jar /tika-app-1.22.jar --text {doc_path}"
+        command = f"java -jar /tika-app.jar --text {doc_path}"
         with open(text_path, "w") as f:
             subprocess.run(command, shell=True, check=True, stdout=f)
         with open(text_path, "r") as f:


### PR DESCRIPTION
Updates the Apache Tika version used. The old version is not available
anymore

Issue https://github.com/okfn-brasil/diario-oficial/issues/147

Signed-off-by: José Guilherme Vanz <jvanz@jvanz.com>