### PR TITLE
Makefile: helper commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,12 @@ For running an existing spider, the command receives its name (in this case, `rs
 $ docker-compose run --rm processing bash -c "cd data_collection && scrapy crawl rs_porto_alegre"
 ```
 
+In order to make our life easier, the following command does the same of the previous one:
+
+```sh
+SPIDER=rs_porto_alegre make run_spider
+```
+
 ## Automated code formatting
 
 The project uses [Black](https://github.com/ambv/black) as an automated tool to format and check code style. If you run `make setup` you should probably be ready to go. It will set up a pre-commit Git hook to format code that happens to be in dissonance with the code style.

--- a/Makefile
+++ b/Makefile
@@ -16,3 +16,12 @@ seed:
 
 test:
 	docker-compose run --rm processing black . --check
+
+run_spider:
+	docker-compose run --rm processing bash -c "cd data_collection && scrapy crawl $(SPIDER)"
+
+sql:
+	docker-compose run --rm postgres psql --username gazette -h postgres -W
+
+clean:
+	find data/full/ -delete


### PR DESCRIPTION
Adds some helpers functions in the Makefile to open the psql, run spiders
and delete the gazette files

Signed-off-by: José Guilherme Vanz <jvanz@jvanz.com>