### PR TITLE
Fix AttributeError trying to get start_date field

### DIFF
--- a/processing/data_collection/gazette/spiders/sc_florianopolis.py
+++ b/processing/data_collection/gazette/spiders/sc_florianopolis.py
@@ -21,7 +21,7 @@ class ScFlorianopolisSpider(BaseGazetteSpider):
             year, month = str(target.year), str(target.month)
             data = dict(ano=year, mes=month, passo="1", enviar="")
             yield FormRequest(url=self.URL, formdata=data, callback=self.parse)
-            if self.start_date is not None and target <= self.start_date:
+            if hasattr(self, "start_date") and target <= self.start_date:
                 break
 
             target = target - relativedelta(months=1)
@@ -33,7 +33,7 @@ class ScFlorianopolisSpider(BaseGazetteSpider):
                 continue
 
             gazette_date = self.get_date(link)
-            if self.start_date is not None and gazette_date < self.start_date:
+            if hasattr(self, "start_date") and gazette_date < self.start_date:
                 continue
 
             yield Gazette(


### PR DESCRIPTION
After #139, the spider raises an exception if the spider class hasn't a start_date field
Now it's fixed with `hasattr` function.