### PR TITLE
scrapy-deltafetch: avoid crawl the same URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ ENV/
 
 # dolphin
 .directory
+
+# scrapy deltafetch middleware directory
+data/deltafetch

--- a/processing/data_collection/gazette/settings.py
+++ b/processing/data_collection/gazette/settings.py
@@ -8,4 +8,10 @@ ITEM_PIPELINES = {
     "gazette.pipelines.ExtractTextPipeline": 200,
     "gazette.pipelines.PostgreSQLPipeline": 300,
 }
+SPIDER_MIDDLEWARES = {
+    'scrapy_deltafetch.DeltaFetch': 100,
+}
 FILES_STORE = "/mnt/data/"
+# skip already crawled item
+DELTAFETCH_ENABLED = True
+DELTAFETCH_DIR = "/mnt/data/deltafetch"

--- a/processing/requirements.txt
+++ b/processing/requirements.txt
@@ -8,3 +8,4 @@ python-magic==0.4.15
 requests==2.22.0
 scrapy==1.8.0
 SQLAlchemy==1.3.4
+scrapy-deltafetch==1.2.1


### PR DESCRIPTION
Adds the scrapy-deltafetch middleware. It allow us to drop item which
already has been crawled. It uses the URL to identify if an item has
already been download. Even if it can causes issues if the same URL
points to a different data in the future, it sounds reasonable to add it
to avoid waste of resources. Furthermore, it is always possible to set
the middleware to reset and allow all the item to be crawled again.

https://github.com/okfn-brasil/diario-oficial/issues/86

Signed-off-by: José Guilherme Vanz <jvanz@jvanz.com>