### PR TITLE
build and publish container image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,34 @@
+name: Building container image
+on: 
+  push:
+    branches:
+      - master
+ 
+env:
+  NAMESPACE: ${{ secrets.NAMESPACE }}
+  USERNAME: ${{ secrets.USERNAME }}
+  PASSWORD: ${{ secrets.PASSWORD }}
+
+jobs:
+    build-image:
+        name: Building container image
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout source code
+              uses: actions/checkout@master
+
+            - name: Build and tag the image
+              run: |
+                  make build
+
+            - name: Docker login
+              run: |
+                  docker login --username=$USERNAME --password=$PASSWORD
+
+            - name: Publish container images
+              run: |
+                  make publish
+
+            - name: Docker logout
+              run: |
+                  docker logout

--- a/Makefile
+++ b/Makefile
@@ -25,3 +25,11 @@ sql:
 
 clean:
 	find data/full/ -delete
+
+build:
+	docker build -t $(NAMESPACE)/diario-oficial:$(shell date --rfc-3339=date --utc) -t $(NAMESPACE)/diario-oficial:latest processing
+
+publish:
+	docker push $(NAMESPACE)/diario-oficial:$(shell date --rfc-3339=date --utc) 
+	docker push $(NAMESPACE)/diario-oficial:latest
+


### PR DESCRIPTION
Adds github workflow to build and publish a container image. The
namespace, username and password used to publish the image in the
registry should be set in the github secrets

Issue #159
Issue #163

Signed-off-by: José Guilherme Vanz <jvanz@jvanz.com>