### PR TITLE
Update Apache Tika to 1.24 in Dockerfile

### DIFF
--- a/processing/Dockerfile
+++ b/processing/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /mnt/code
 COPY requirements.txt requirements.txt
 
 # install Apache Tika
-ADD http://ftp.unicamp.br/pub/apache/tika/tika-app-1.23.jar /tika-app.jar
+ADD http://ftp.unicamp.br/pub/apache/tika/tika-app-1.24.jar /tika-app.jar
 
 RUN adduser --system -u ${LOCAL_USER_ID:-1000} gazette \
 	&& apt-get update \


### PR DESCRIPTION
The [link](http://ftp.unicamp.br/pub/apache/tika/tika-app-1.23.jar) to download Apache Tika 1.23 is broken on Dockerfile. Can we update to 1.24?