### PR TITLE
Fix LOCAL_USER_ID envvar behaviour

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,10 @@ services:
     image: postgres:11.3-alpine
 
   processing:
-    build: processing
+    build:
+      context: processing
+      args:
+        - LOCAL_USER_ID
     depends_on:
       - postgres
     env_file:

--- a/processing/Dockerfile
+++ b/processing/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.7-stretch
 
+ARG LOCAL_USER_ID
+
 WORKDIR /mnt/code
 
 COPY requirements.txt requirements.txt


### PR DESCRIPTION
The `env_file` option in the `docker-compose.yml` exports the envvars when running the container but not when building it.

Unfortunately, the Compose's documentation does not cover it well (or I couldn't find it there). The best I could find to link here was this note

![image](https://user-images.githubusercontent.com/26327506/82135422-256fc200-97d9-11ea-9e4d-37048e90aad3.png)

on the [environment section](https://docs.docker.com/compose/compose-file/#environment) that tells us to use the `args` sub-option under the `build` option to define envvars.

To complement this, if no Compose is used, the `--build-arg` option of `docker build` has to be used to export envvars at build time. As specified in the [`ARG` statement documentation](https://docs.docker.com/engine/reference/builder/#arg).


