### PR TITLE
FECAM website's DOM structure has been changed.

### DIFF
--- a/processing/data_collection/gazette/spiders/base.py
+++ b/processing/data_collection/gazette/spiders/base.py
@@ -54,7 +54,7 @@ class FecamGazetteSpider(scrapy.Spider):
         Method to get all the relevant documents list and their dates from the page
         """
         documents = []
-        elements = response.xpath('/html/body/div[1]/div[3]/div[5]/p[@class="quiet"]')
+        elements = response.xpath('/html/body/div[1]/div[4]/div[5]/p[@class="quiet"]')
         for e in elements:
             if "Visualizar" in e.xpath("a[1]/text()").get():
                 # The element does not contain the element with the file URL.
@@ -72,7 +72,7 @@ class FecamGazetteSpider(scrapy.Spider):
         Get the last page number available in the pages navigation menu
         """
         href = response.xpath(
-            "/html/body/div[1]/div[3]/div[4]/div/div/ul/li[14]/a/@href"
+            "/html/body/div[1]/div[4]/div[4]/div/div/ul/li[14]/a/@href"
         ).get()
         result = re.search("Search_page=(\d+)", href)
         if result is not None:


### PR DESCRIPTION
The FECAM website's DOM structure has been changed. This commit fix the
spider to allow it continue find the gazette files.

Signed-off-by: José Guilherme Vanz <jvanz@jvanz.com>