### PR TITLE
Fecam spider: filter item by date

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,3 +35,6 @@ publish:
 
 shell:
 	docker-compose run --rm processing bash -c "cd data_collection && scrapy shell"
+
+run_spider_since:
+	docker-compose run --rm processing bash -c "cd data_collection && scrapy crawl -a start_date=$(START_DATE) $(SPIDER)"

--- a/processing/data_collection/gazette/settings.py
+++ b/processing/data_collection/gazette/settings.py
@@ -13,3 +13,4 @@ FILES_STORE = "/mnt/data/"
 # skip already crawled item
 DELTAFETCH_ENABLED = True
 DELTAFETCH_DIR = "/mnt/data/deltafetch"
+DELTAFETCH_RESET = True # reset deltafetch middleware state

--- a/processing/data_collection/gazette/spiders/base.py
+++ b/processing/data_collection/gazette/spiders/base.py
@@ -18,7 +18,7 @@ class BaseGazetteSpider(scrapy.Spider):
                 self.start_date = parsed_data.date()
 
 
-class FecamGazetteSpider(scrapy.Spider):
+class FecamGazetteSpider(BaseGazetteSpider):
 
     URL = "https://www.diariomunicipal.sc.gov.br/site/"
     total_pages = None


### PR DESCRIPTION
Updates the FECAM spider to be a subclass of the BaseGazetteSpider
class. Thus, the user can filter the gazette items found by date. Using
the "start_date" spider argument.

Related to: https://github.com/okfn-brasil/diario-oficial/issues/172

Signed-off-by: José Guilherme Vanz <jvanz@jvanz.com>