### PR TITLE
QueridoDiarioFilesPipeline class

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ sql:
 	docker-compose run --rm postgres psql --username gazette -h postgres -W
 
 clean:
-	find data/full/ -delete
+	find ./data/* -type d -exec rm -rv {} \;
 
 build:
 	docker build -t $(NAMESPACE)/diario-oficial:$(shell date --rfc-3339=date --utc) -t $(NAMESPACE)/diario-oficial:latest processing

--- a/processing/data_collection/gazette/pipelines.py
+++ b/processing/data_collection/gazette/pipelines.py
@@ -1,4 +1,4 @@
-from  pathlib import Path
+from pathlib import Path
 import hashlib
 import magic
 import os
@@ -13,6 +13,7 @@ from sqlalchemy.orm import sessionmaker
 
 from database.models import Gazette, initialize_database
 from gazette.settings import FILES_STORE
+
 
 class PostgreSQLPipeline:
     def __init__(self):
@@ -167,10 +168,11 @@ class QueridoDiarioFilesPipeline(FilesPipeline):
 
     def file_path(self, request, response=None, info=None):
         filepath = super().file_path(request, response, info)
-        datestr = request.item["date"].strftime("%d-%m-%Y")
         # The default path from the scrapy class begins with "full/". In this
         # class we replace that with the gazette date.
-        return str(pathlib.Path(datestr, filepath[5:]))
+        datestr = request.item["date"].strftime("%d-%m-%Y")
+        filename = Path(filepath).name
+        return str(Path(datestr, filename))
 
     def get_media_requests(self, item, info):
         urls = ItemAdapter(item).get(self.files_urls_field)

--- a/processing/data_collection/gazette/pipelines.py
+++ b/processing/data_collection/gazette/pipelines.py
@@ -1,11 +1,9 @@
+from  pathlib import Path
 import hashlib
 import magic
 import os
-import pathlib
 import subprocess
 
-from database.models import Gazette, initialize_database
-from gazette.settings import FILES_STORE
 from itemadapter import ItemAdapter
 from scrapy.exceptions import DropItem
 from scrapy.http import Request
@@ -13,6 +11,8 @@ from scrapy.pipelines.files import FilesPipeline
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import sessionmaker
 
+from database.models import Gazette, initialize_database
+from gazette.settings import FILES_STORE
 
 class PostgreSQLPipeline:
     def __init__(self):

--- a/processing/requirements.txt
+++ b/processing/requirements.txt
@@ -10,3 +10,4 @@ scrapy==1.8.0
 SQLAlchemy==1.3.4
 scrapy-deltafetch==1.2.1
 boto3==1.14.16
+itemadapter==0.1.0


### PR DESCRIPTION
Adds the QueridoDiarioFilesPipeline class. A specialization of the scrapy FilesPipeline. The new class will allow the users to store in the backends available in the scrapy class but changing the directory where the file will be stored. The current version will keep all the gazettes files from the same date in the same directory.

Issue #165 
